### PR TITLE
Fix Homebrew Tap link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,6 @@ homebrew-tap
 
 ``homebrew-tap`` is the `Homebrew tap`_ for `ClusterHQ`_.
 
-.. _Homebrew tap: https://github.com/Homebrew/homebrew/wiki/brew-tap
+.. _Homebrew tap: https://github.com/Homebrew/homebrew/tree/master/share/doc/homebrew#readme
 .. _ClusterHQ: https://github.com/ClusterHQ
 


### PR DESCRIPTION
Homebrew Tap wiki has moved.
